### PR TITLE
Retry when rate limits are hit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Description: Work with ClickUp.
 License: MIT + file LICENSE
 LazyLoad: yes
 LazyData: true
-Imports: httr, jsonlite
+Imports: httr, jsonlite, rlang
 Suggests: knitr
 URL: https://github.com/psolymos/clickrup
 BugReports: https://github.com/psolymos/clickrup/issues

--- a/R/internals.R
+++ b/R/internals.R
@@ -108,7 +108,7 @@
     if (!is.null(reset)) {
         # sleep as indicated, and then retry at most twice
         sleeps <- c(ceiling(as.numeric(reset) - as.numeric(Sys.time())), 1, 1)
-        message("ClickUp API: Rate limit reached, sleeping for ", sleeps, " seconds", appendLF = FALSE)
+        message("ClickUp API: Rate limit reached, sleeping for ", sleeps[[1]], " seconds", appendLF = FALSE)
     } else {
         sleeps <- c(1, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4)
         # sum(sleeps) >= 60

--- a/R/internals.R
+++ b/R/internals.R
@@ -104,10 +104,17 @@
         return(resp)
     }
 
-    message("ClickUp API: Rate limit reached", appendLF = FALSE)
+    reset <- resp$headers[["x-ratelimit-reset"]]
+    if (!is.null(reset)) {
+        # sleep as indicated, and then retry at most twice
+        sleeps <- c(ceiling(as.numeric(reset) - as.numeric(Sys.time())), 1, 1)
+        message("ClickUp API: Rate limit reached, sleeping for ", sleeps, " seconds", appendLF = FALSE)
+    } else {
+        sleeps <- c(1, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4)
+        # sum(sleeps) >= 60
+        message("ClickUp API: Rate limit reached, sleeping for up to ", sum(sleeps), "seconds", appendLF = FALSE)
+    }
 
-    # sum(sleeps) >= 60
-    sleeps <- c(1, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4)
     for (sleep in sleeps) {
         Sys.sleep(sleep)
         message(".", appendLF = FALSE)


### PR DESCRIPTION
I tried with `httr::RETRY()`, a home-grown solution works better because `RETRY()` doesn't take into account the `x-ratelimit-reset` header.

``` r
library(clickrup)
#> clickrup 0.0.3    2021-04-09
for (i in 1:250) {
  message("#", appendLF = FALSE)
  cu_get_teams()
}
#> #
#> ####################################################################################################ClickUp API: Rate limit reached, sleeping for 54 seconds.
#> ####################################################################################################ClickUp API: Rate limit reached, sleeping for 53 seconds.
#> #################################################

message()
#> 
```

<sup>Created on 2021-10-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
