### PR TITLE
cu_get_time_entries_within_date_range() is not paged

### DIFF
--- a/R/api-timetracking-v2.R
+++ b/R/api-timetracking-v2.R
@@ -47,7 +47,7 @@ NULL
 ##    Number
 cu_get_time_entries_within_date_range <- function(team_id,
 start_date, end_date, assignee) {
-    .cu_get("team", team_id, "time_entries",
+    .cu_get("team", team_id, "time_entries", paging = FALSE,
         query = list(
             "start_date"=start_date,
             "end_date"=end_date,

--- a/R/internals.R
+++ b/R/internals.R
@@ -36,11 +36,11 @@
 }
 
 ## convenience function for GET requests with support for paging
-.cu_get <- function(..., query=list()) {
+.cu_get <- function(..., query=list(), paging=TRUE) {
     chunk <- .cu_get_page(..., query = query)
     out <- chunk
     page <- 0
-    while (length(chunk) == 1 && length(chunk[[1]]) == 100) {
+    while (paging && length(chunk) == 1 && length(chunk[[1]]) == 100) {
         page <- page + 1
         query$page <- page
         chunk <- .cu_get_page(..., query = query)


### PR DESCRIPTION
For an assignee with exactly 100 time entries, `cu_get_time_entries_within_date_range()` loops infinitely.