### PR TITLE
Use supplied cu_token in first get batch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: clickrup
 Type: Package
 Title: Interacting with the ClickUp v2 API from R
-Version: 0.0.5
+Version: 0.0.6
 Date: 2021-12-12
 Authors@R: 
     c(person(given = "Peter",

--- a/R/internals.R
+++ b/R/internals.R
@@ -37,7 +37,7 @@
 
 ## convenience function for GET requests with support for paging
 .cu_get <- function(..., query=list(), paging=TRUE, cu_token = NULL) {
-    chunk <- .cu_get_page(..., query = query)
+    chunk <- .cu_get_page(..., query = query, cu_token = cu_token)
     out <- chunk
     page <- 0
     while (paging && length(chunk) == 1 && length(chunk[[1]]) == 100) {


### PR DESCRIPTION
Fix a bug in the new cu_token implementation, wherein the supplied token wasn't used for the first get call.